### PR TITLE
Hotfix seeds.rb brackets

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -174,7 +174,9 @@ Station.create([
 	  condition: 99,
 	  tier: 3,
 	  icon: 'Reparaturgebaeude.png'
-
+    }
+])
+    
 # Creator for Messages
 Message.create([
 	# Messages for Science


### PR DESCRIPTION
Wir haben für Station.create am Ende die Klammern vergessen.